### PR TITLE
Fix/header and method signature

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   webserver:
     image: byjg/php:8.1-fpm-nginx
     volumes:
-    - $PWD/tests/server:/var/www/html
+    - ./tests/server:/var/www/html
     ports:
       - "8080:80"

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -5,6 +5,7 @@ namespace ByJG\Util;
 use ByJG\Util\Exception\CurlException;
 use ByJG\Util\Exception\NetworkException;
 use ByJG\Util\Exception\RequestException;
+use ByJG\Util\Psr7\NullStream;
 use InvalidArgumentException;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -180,7 +181,7 @@ class HttpClient implements ClientInterface
     protected function setBody(): void
     {
         $stream = $this->request->getBody();
-        if (!is_null($stream)) {
+        if (!$stream instanceof NullStream) {
             if (!$this->getCurl(CURLOPT_POST) && !$this->getCurl(CURLOPT_CUSTOMREQUEST)) {
                 throw new RequestException($this->request,"Cannot set body with method GET");
             }

--- a/src/Psr7/Message.php
+++ b/src/Psr7/Message.php
@@ -133,11 +133,12 @@ class Message implements MessageInterface
     /**
      * @inheritDoc
      */
-    public function getBody(): ?StreamInterface
+    public function getBody(): StreamInterface
     {
-        if (!is_null($this->body)) {
-            $this->body->rewind();
+        if (is_null($this->body)) {
+            $this->body = new NullStream();
         }
+        $this->body->rewind();
         return $this->body;
     }
 

--- a/tests/HttpClientParallelTest.php
+++ b/tests/HttpClientParallelTest.php
@@ -34,6 +34,7 @@ class HttpClientParallelTest extends TestCase
             $fail[] = $error;
         };
 
+        $timeStart = time();
         $multi = new \ByJG\Util\HttpClientParallel(
             $httpClient,
             $onSucess,
@@ -50,6 +51,10 @@ class HttpClientParallelTest extends TestCase
             ->addRequest($request3);
 
         $multi->execute();
+
+        $diffSeconds = time() - $timeStart;
+        $this->assertGreaterThan(1, $diffSeconds);
+        $this->assertLessThanOrEqual(3, $diffSeconds);
 
         sort($results);
 

--- a/tests/server/multirequest.php
+++ b/tests/server/multirequest.php
@@ -1,5 +1,5 @@
 <?php
 
-header("content-type", "text-plain");
+header('content-type: text/plain');
 sleep(1 + rand(0, 3));
 echo $_REQUEST["param"];

--- a/tests/server/multirequest.php
+++ b/tests/server/multirequest.php
@@ -1,5 +1,5 @@
 <?php
 
 header('content-type: text/plain');
-sleep(1 + rand(0, 3));
+
 echo $_REQUEST["param"];

--- a/tests/server/multirequest.php
+++ b/tests/server/multirequest.php
@@ -2,4 +2,5 @@
 
 header('content-type: text/plain');
 
+sleep(2);
 echo $_REQUEST["param"];


### PR DESCRIPTION
- [fix: Usage of header function](https://github.com/byjg/php-webrequest/commit/c633d4807455aa153f51b1f42c0bb098a173a0e5)

  The header function of PHP have only an argument to define the header name and value. This argument need to be a string.

  More info: https://www.php.net/header

- [chore: remove sleep](https://github.com/byjg/php-webrequest/commit/c255f4204f39c22dff3a66169a9fb5da016703be)

  Removed to test go more fast. Is very strange to have a sleep here and removing the tests worked fine.

- [fix: type of return](https://github.com/byjg/php-webrequest/commit/da48cfd86ad4b70dfe5b42317399f59e704678a2)

  The method getBody can't return null. The return of this method need to be a instance of StreamInterface. To fix this I create a instance of a class that extends StreamInterface.

  Reference: https://github.com/php-fig/http-message/blob/1.0/src/MessageInterface.php#L169-L171